### PR TITLE
Update colors

### DIFF
--- a/team-data.json
+++ b/team-data.json
@@ -3,7 +3,7 @@
         "Atlanta Hawks" :           ["000080", "FF0000", "C0C0C0"],
         "Boston Celtics" :          ["009E60", "FFFFFF", "000000", "EFE196"],
         "Brooklyn Nets" :           ["000000", "FFFFFF"],
-        "Charlotte Hornets" :       ["1C0C65", "1D8CAA", "969491", "000000"],
+        "Charlotte Hornets" :       ["1C0C65", "1D8CAA", "000000", "969491", "000000", "75AADB"],
         "Chicago Bulls" :           ["D4001F", "000000", "FFFFFF"],
         "Cleveland Cavaliers" :     ["b3121d", "FFD700", "000080", "FFFFFF"],
         "Dallas Mavericks" :        ["0b60ad", "072156", "A9A9A9", "FFFFFF"],
@@ -27,7 +27,7 @@
         "Portland Trail Blazers" :  ["F0163A", "B6BFBF", "000000", "FFFFFF"],
         "Sacramento Kings" :        ["753BBD", "000000", "8A8D8F", "FFFFFF"],
         "San Antonio Spurs" :       ["000000", "BEC8C9", "FFFFFF"],
-        "Toronto Raptors" :         ["B31B1B", "000000", "708090"],
+        "Toronto Raptors" :         ["B31B1B", "000000", "FFFFFF", "708090"],
         "Utah Jazz" :               ["00275D", "FF9100", "0D4006", "B5B5B5"],
         "Washington Wizards" :      ["C60C30", "FFFFFF", "002244", "BCC4CC" ]
     },


### PR DESCRIPTION
Added white in the Toronto Raptors colors list as well as light blue and black in Charlotte Hornets color list