### PR TITLE
Load stylesheet in template

### DIFF
--- a/src/handlebars/index.hbs
+++ b/src/handlebars/index.hbs
@@ -7,6 +7,7 @@
         <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     {{!-- <link href="http://fonts.googleapis.com/css?family=Droid+Sans:400,700" rel="stylesheet" type="text/css"> --}}
+    <link rel="stylesheet" href="assets/styles/styles.css" />
 </head>
 <body>
     <header id="header">

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -27,9 +27,6 @@ var TeamColors = {
     // Initialize the view
     init: function(){
 
-        // Load the page's CSS
-        loadCSS("assets/styles/styles.css");
-
         // Append the "Back to Top" link
         $('body').append('<a href="#" id="top">&#8593;</a>');
 


### PR DESCRIPTION
The lag that occurs before the document is ready for modification
causes a small flicker to occur on page load.

Moving the stylesheet into the template itself solves this problem.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/teamcolors/teamcolors.github.io/52)
<!-- Reviewable:end -->
