### PR TITLE
Update mlb.json

### DIFF
--- a/src/scripts/data/leagues/mlb.json
+++ b/src/scripts/data/leagues/mlb.json
@@ -134,7 +134,7 @@
     {
         "name": "San Diego Padres",
         "colors": {
-            "hex"   :   ["05143F"]
+            "hex"   :   ["002D62",      "FEC325",           "7F411C",           "A0AAB2"]
         }
     },
     {


### PR DESCRIPTION
The San Diego Padres' colors should be updated, per the team's 2016 Style Guide: http://sandiego.padres.mlb.com/documents/6/8/2/159803682/SP2016_StyleGuide_hgwfn95m.pdf#page=4