### PR TITLE
Pittsburgh Penguins update

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -97,6 +97,12 @@ The extracted colors are in HEX form and their RGB counterparts are generated pr
 - [American League logo slick](http://i.imgur.com/RP5kBSI.png)
 - [National League logo slick](http://i.imgur.com/FcuizSx.png)
 
-### EPL, MLS, NHL
+### NHL
+
+NHL colors are currently approximations, with the exceptions listed below. I am working on getting official colors of the remaining teams.
+
+- [Pittsburgh Penguins](http://penguins.nhl.com/v2/ext/pdf/15.16%20Sponsor%20Playbook/2015-16%20Partner%20Playbook%20-%20Brand%20Style%20Guide%20-%2019.pdf)
+
+### EPL, MLS
 
 These leagues’ teams and colors are currently approximations. I am working on getting official colors. If you know how/where to find them, please open an issue here in Github.

--- a/src/scripts/data/leagues/nhl.json
+++ b/src/scripts/data/leagues/nhl.json
@@ -133,9 +133,13 @@
     },
     {
         "name": "Pittsburgh Penguins",
-        "colors": {
-            "hex"   :   ["000000",          "D1BD80"]
-        }
+        "colors" : {
+            "hex"   :   ["CCCC99",          "000000",       "FFCC33"],
+            "rgb"   :   ["207 196 147",     "0 0 0",        "255 184 28"],
+            "cmyk"  :   ["6 8 35 12",       "0 0 0 100",    "0 28 89 0"],
+            "pms"   :   ["4535 C",          "Black C",      "1235 C"]
+        },
+        "src" : "http://penguins.nhl.com/v2/ext/pdf/15.16%20Sponsor%20Playbook/2015-16%20Partner%20Playbook%20-%20Brand%20Style%20Guide%20-%2019.pdf"
     },
     {
         "name": "San Jose Sharks",


### PR DESCRIPTION
* Updating readme.
* Updating colors based on official [Penguins brand style guide](http://penguins.nhl.com/v2/ext/pdf/15.16%20Sponsor%20Playbook/2015-16%20Partner%20Playbook%20-%20Brand%20Style%20Guide%20-%2019.pdf).